### PR TITLE
feat: add revert prefix in cc workflow

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -17,7 +17,7 @@ jobs:
           COMMIT_MSGS=$(git log --no-merges --format=%s origin/main..HEAD)
           for msg in "${COMMIT_MSGS[@]}"; do
             echo "Checking: $msg"
-            if [[ ! $msg =~ ^(ci|feat|fix|docs|style|refactor|perf|test|chore|build)(\(.+\))?:\ .+ ]]; then
+            if [[ ! $msg =~ ^(ci|feat|fix|docs|style|refactor|perf|test|chore|build|revert)(\(.+\))?:\ .+ ]]; then
               echo "error: invalid commit message: $msg"
               exit 1
             fi

--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ This means commit with the following prefixes in the summary line are allowed:
 - refactor
 - style
 - test
+- revert
 
 ## dart/
 

--- a/general/conventional_commit_check.yml
+++ b/general/conventional_commit_check.yml
@@ -8,7 +8,7 @@ check_conventional_commits:
   script:
     - git fetch origin ${CI_DEFAULT_BRANCH}
     # List all non merge commits specific to this branch and checks their summary line with grep
-    - "git log --pretty=format:%s --no-merges HEAD ^origin/main |  ( ! grep -v -E '^(ci|fix|feat|chore|test|perf|refactor|style|builds|docs): ' )"
+    - "git log --pretty=format:%s --no-merges HEAD ^origin/main |  ( ! grep -v -E '^(ci|fix|feat|chore|test|perf|refactor|style|builds|docs|revert): ' )"
   rules:
     - if: '$CI_MERGE_REQUEST_IID'
 


### PR DESCRIPTION
There's one more type of commit in conventional commits and the prefix for it is `revert`. This PR adds the check for it in the respective workflow.

Refer: https://www.conventionalcommits.org/en/v1.0.0/#how-does-conventional-commits-handle-revert-commits