### PR TITLE
chore: new flutter template

### DIFF
--- a/.github/actions/flutter-prepare/action.yml
+++ b/.github/actions/flutter-prepare/action.yml
@@ -1,0 +1,34 @@
+name: "Prepare flutter and ssh"
+description: "Sets up the flutter container and ssh keys for pulling from private repos"
+
+inputs:
+  ssh_key:
+    description: "SSH key to pull private dependencies."
+    required: true
+  flutter_version:
+    description: "Flutter version"
+    type: string
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Enable pulling private dependencies
+      shell: bash
+      run: |
+          mkdir -p ~/.ssh
+          echo "${{inputs.ssh_key}}" > ~/.ssh/id_rsa
+          chmod 600 ~/.ssh/id_rsa
+          eval $(ssh-agent)
+          ssh-add ~/.ssh/id_rsa
+          # Fixup the permissions after the checkout action
+          # see https://github.com/actions/checkout/issues/766 and https://github.com/actions/checkout/issues/363
+          chown -R $(whoami) .
+    - name: Setup flutter
+      uses: subosito/flutter-action@48cafc24713cca54bbe03cdc3a423187d413aafa
+      with:
+        flutter-version: ${{ inputs.flutter_version }}
+        cache: true
+    - run: |
+        [ "${{ inputs.flutter_version }}" -ge "3.16.0" ] && flutter --disable-analytics; dart --disable-analytics || flutter --disable-telemetry; dart --disable-telemetry
+      shell: bash

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Fetch dependencies
         working-directory: ${{ inputs.directory }}
         run: |
-          flutter pub get
+          dart pub get
       - name: Check formatting
         working-directory: ${{ inputs.directory }}
         run: |
@@ -64,8 +64,8 @@ jobs:
       - name: Run analyzer
         working-directory: ${{ inputs.directory }}
         run: |
-          flutter analyze || (echo '```diff' >> "$GITHUB_STEP_SUMMARY"; git diff >> "$GITHUB_STEP_SUMMARY"; echo '```' >> "$GITHUB_STEP_SUMMARY"; exit 1)
+          dart analyze || (echo '```diff' >> "$GITHUB_STEP_SUMMARY"; git diff >> "$GITHUB_STEP_SUMMARY"; echo '```' >> "$GITHUB_STEP_SUMMARY"; exit 1)
       - name: Sort imports
         working-directory: ${{ inputs.directory }}
         run: |
-          dart pub run import_sorter:main --no-comments --exit-if-changed || (echo '```diff' >> "$GITHUB_STEP_SUMMARY"; git diff >> "$GITHUB_STEP_SUMMARY"; echo '```' >> "$GITHUB_STEP_SUMMARY"; exit 1)
+          dart run import_sorter:main --no-comments --exit-if-changed || (echo '```diff' >> "$GITHUB_STEP_SUMMARY"; git diff >> "$GITHUB_STEP_SUMMARY"; echo '```' >> "$GITHUB_STEP_SUMMARY"; exit 1)

--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -1,0 +1,45 @@
+name: "Run flutter specific github actions"
+
+on:
+  workflow_call:
+    inputs:
+      env_file:
+        description: "Path to an .env file to read flutter_version and/or dart_version from. Please note that these variables will overwrite dart_version and flutter_version."
+        type: string
+        required: false
+      directory:
+        description: "The subdirectory for the dart project, defaults to the current directory."
+        type: string
+        required: false
+        default: "."
+    secrets:
+      ssh_key:
+        description: "SSH key to pull private dependencies"
+        required: false
+
+jobs:
+  flutter_analyzer:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Read env file
+        run: cat ${{ inputs.env_file }} >> $GITHUB_ENV
+      - uses: famedly/frontend-ci-templates/.github/actions/flutter-prepare@td/flutterprep
+        with:
+            ssh_key: "${{ secrets.ssh_key }}"
+      - name: Fetch dependencies
+        working-directory: ${{ inputs.directory }}
+        run: |
+          flutter pub get
+      - name: Check formatting
+        working-directory: ${{ inputs.directory }}
+        run: |
+          dart format lib/ test/ test_driver/ --set-exit-if-changed || (echo '```diff' >> "$GITHUB_STEP_SUMMARY"; git diff >> "$GITHUB_STEP_SUMMARY"; echo '```' >> "$GITHUB_STEP_SUMMARY"; exit 1)
+      - name: Run analyzer
+        working-directory: ${{ inputs.directory }}
+        run: |
+          flutter analyze || (echo '```diff' >> "$GITHUB_STEP_SUMMARY"; git diff >> "$GITHUB_STEP_SUMMARY"; echo '```' >> "$GITHUB_STEP_SUMMARY"; exit 1)
+      - name: Sort imports
+        working-directory: ${{ inputs.directory }}
+        run: |
+          dart run import_sorter:main --no-comments --exit-if-changed || (echo '```diff' >> "$GITHUB_STEP_SUMMARY"; git diff >> "$GITHUB_STEP_SUMMARY"; echo '```' >> "$GITHUB_STEP_SUMMARY"; exit 1)

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -43,5 +43,5 @@ jobs:
             await github.rest.actions.deleteArtifact({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              artifact_id: ${{artifact.id}},
+              artifact_id: ${{ github.env.artifact_id }}, // is this flow even used? deperacate it soon if not
             });


### PR DESCRIPTION
why not just use the old dart one? well it was ridiculed with too many options to do the same thing, and ideally having your dart only and flutter templates different sounds like a nice idea, the prepare flutter and ssh composite action now takes in a flutter version to account for any breaking changes with flutter