### PR TITLE
chore: update GitHub Action pins

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -45,7 +45,7 @@ jobs:
           path: ~/.pub-cache
           key: ${{ runner.os }}-${{ hashFiles('**/pubspec.lock') }}
       - name: Enable pulling private dependencies
-        uses: famedly/frontend-ci-templates/.github/actions/dart-prepare@main
+        uses: famedly/frontend-ci-templates/.github/actions/dart-prepare@e8167567258899ed2a5bcc7fe04c79ad78f87967
         with:
           ssh_key: "${{ secrets.ssh_key }}"
           container_mode: "false"

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Clean repository
         run: rm -rf ./*
       - name: Download Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@484a0b528fb4d7bd804637ccb632e47a0e638317
         with:
           name: ${{inputs.artifact_name}}
       - name: Publish to GitHub Pages
@@ -30,7 +30,7 @@ jobs:
           git commit -m "Publish to GitHub Pages"
           git push --force origin gh-pages
       - name: Delete Artifact
-        uses: actions/github-script@v5
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
         with:


### PR DESCRIPTION
## Summary
- Pin all external GitHub Actions in workflows to current upstream default-branch commit SHAs.
- Includes actions discovered from every `uses:` entry in `.github/**/*.yml` and `.github/**/*.yaml`.

## Verification
- Commit is GPG-signed locally.
- CI on this PR should validate the updated action refs.