### PR TITLE
fix: Support token auth for private Dart dependencies

### DIFF
--- a/.github/actions/dart-prepare/action.yml
+++ b/.github/actions/dart-prepare/action.yml
@@ -5,16 +5,19 @@ inputs:
   ssh_key:
     description: "SSH key to pull private dependencies."
     required: false
+  github_token:
+    description: "GitHub token to pull private dependencies over HTTPS."
+    required: false
   container_mode:
-    description: "Wether this job runs inside of a container or directly on the VM."
+    description: "Whether this job runs inside of a container or directly on the VM."
     default: "true"
     required: false
 
 runs:
   using: composite
   steps:
-    - name: Enable pulling private dependencies
-      if: ${{inputs.ssh_key}}
+    - name: Enable pulling private dependencies with SSH
+      if: ${{ inputs.ssh_key != '' && inputs.github_token == '' }}
       run: |
         if [[ "${{ inputs.container_mode }}" == "true" ]]; then
           mkdir -p -m 0700 ~/.ssh/ && touch ~/.ssh/known_hosts
@@ -40,4 +43,17 @@ runs:
         if which dart > /dev/null; then dart --disable-analytics; fi
         # Convert https dependencies in pubspec.yaml to ssh
         git config --global url."git@github.com:".insteadOf "https://github.com/"
+      shell: bash
+
+    - name: Enable pulling private dependencies with GitHub token
+      if: ${{ inputs.github_token != '' }}
+      run: |
+        # Fixup the permissions after the checkout action
+        # see https://github.com/actions/checkout/issues/766 and https://github.com/actions/checkout/issues/363
+        chown -R $(whoami) .
+        if which flutter > /dev/null; then flutter --disable-analytics; fi
+        if which dart > /dev/null; then dart --disable-analytics; fi
+        git config --global url."https://x-access-token:${{ inputs.github_token }}@github.com/".insteadOf "https://github.com/"
+        git config --global url."https://x-access-token:${{ inputs.github_token }}@github.com/".insteadOf "git@github.com:"
+        git config --global url."https://x-access-token:${{ inputs.github_token }}@github.com/".insteadOf "ssh://git@github.com/"
       shell: bash

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -21,6 +21,9 @@ on:
       ssh_key:
         description: "SSH key to pull private dependencies"
         required: false
+      github_token:
+        description: "GitHub token to pull private dependencies over HTTPS"
+        required: false
 
 jobs:
   dart_analyzer:
@@ -48,6 +51,7 @@ jobs:
         uses: famedly/frontend-ci-templates/.github/actions/dart-prepare@main
         with:
           ssh_key: "${{ secrets.ssh_key }}"
+          github_token: "${{ secrets.github_token }}"
           container_mode: "false"
       - name: Fetch dependencies
         id: deps


### PR DESCRIPTION
## Summary
- Add optional GitHub token authentication to the Dart prepare action for private GitHub dependencies.
- Pass the token through the reusable Dart workflow so Dependabot-style runs can resolve private Git dependencies over HTTPS.
