### PR TITLE
fix: Forward renamed Dart dependency token

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -51,7 +51,7 @@ jobs:
         uses: famedly/frontend-ci-templates/.github/actions/dart-prepare@main
         with:
           ssh_key: "${{ secrets.ssh_key }}"
-          famedly_github_token: "${{ secrets.github_token }}"
+          famedly_github_token: "${{ secrets.famedly_github_token }}"
           container_mode: "false"
       - name: Fetch dependencies
         id: deps


### PR DESCRIPTION
## Summary
- Forward the `famedly_github_token` workflow secret to the Dart prepare action.
- Fix the reusable Dart workflow still referencing the old reserved `github_token` name.

## Test plan
- Validated `.github/workflows/dart.yml` with Ruby YAML parser.
- Ran `git diff --check`.


Made with [Cursor](https://cursor.com)