### PR TITLE
fix: use git config --add for token insteadOf rewrites

### DIFF
--- a/.github/actions/dart-prepare/action.yml
+++ b/.github/actions/dart-prepare/action.yml
@@ -53,7 +53,9 @@ runs:
         chown -R $(whoami) .
         if which flutter > /dev/null; then flutter --disable-analytics; fi
         if which dart > /dev/null; then dart --disable-analytics; fi
-        git config --global url."https://x-access-token:${{ inputs.famedly_github_token }}@github.com/".insteadOf "https://github.com/"
-        git config --global url."https://x-access-token:${{ inputs.famedly_github_token }}@github.com/".insteadOf "git@github.com:"
-        git config --global url."https://x-access-token:${{ inputs.famedly_github_token }}@github.com/".insteadOf "ssh://git@github.com/"
+        # --add is required: plain `git config` overwrites the previous value
+        # for the same url base key, leaving only the last insteadOf rewrite.
+        git config --global --add url."https://x-access-token:${{ inputs.famedly_github_token }}@github.com/".insteadOf "https://github.com/"
+        git config --global --add url."https://x-access-token:${{ inputs.famedly_github_token }}@github.com/".insteadOf "git@github.com:"
+        git config --global --add url."https://x-access-token:${{ inputs.famedly_github_token }}@github.com/".insteadOf "ssh://git@github.com/"
       shell: bash


### PR DESCRIPTION
## Summary

- `git config url.<base>.insteadOf <value>` **without `--add`** overwrites the previous value for the same url base key. Our three rewrites in `dart-prepare` therefore collapsed into a single one — only the last (`ssh://git@github.com/`) survived.
- As a result, `https://github.com/...` git dependencies were **not** rewritten to the token URL, and `flutter pub get` failed with `fatal: could not read Username for 'https://github.com'` (see e.g. famedly/app#7173).
- Fix: use `git config --global --add` so all three `insteadOf` mappings (`https://`, `git@`, `ssh://`) coexist under the same base.