### PR TITLE
fix: scope token insteadOf rewrites to the famedly org

### DIFF
--- a/.github/actions/dart-prepare/action.yml
+++ b/.github/actions/dart-prepare/action.yml
@@ -55,7 +55,10 @@ runs:
         if which dart > /dev/null; then dart --disable-analytics; fi
         # --add is required: plain `git config` overwrites the previous value
         # for the same url base key, leaving only the last insteadOf rewrite.
-        git config --global --add url."https://x-access-token:${{ inputs.famedly_github_token }}@github.com/".insteadOf "https://github.com/"
-        git config --global --add url."https://x-access-token:${{ inputs.famedly_github_token }}@github.com/".insteadOf "git@github.com:"
-        git config --global --add url."https://x-access-token:${{ inputs.famedly_github_token }}@github.com/".insteadOf "ssh://git@github.com/"
+        # The rewrites are scoped to the famedly org on purpose: rewriting all
+        # of github.com injects the token into public clones too, which makes
+        # Xcode's Swift Package Manager hang during dependency resolution.
+        git config --global --add url."https://x-access-token:${{ inputs.famedly_github_token }}@github.com/famedly/".insteadOf "https://github.com/famedly/"
+        git config --global --add url."https://x-access-token:${{ inputs.famedly_github_token }}@github.com/famedly/".insteadOf "git@github.com:famedly/"
+        git config --global --add url."https://x-access-token:${{ inputs.famedly_github_token }}@github.com/famedly/".insteadOf "ssh://git@github.com/famedly/"
       shell: bash


### PR DESCRIPTION
## Summary

- The token-based `insteadOf` rewrites in `dart-prepare` currently rewrite **all** `github.com` URLs, injecting the token into clones of public repositories as well.
- Xcode's Swift Package Manager cannot handle the rewritten URLs with embedded credentials and **hangs indefinitely** during dependency resolution (Firebase, Sentry, SDWebImage, …) — observed on `build_ios` in famedly/app#7173, where the job stalled for 28+ minutes after `Fetching from https://github.com/google/GoogleAppMeasurement.git...` while an identical build without the token path finishes in ~13 minutes.
- Fix: scope the rewrites to `github.com/famedly/`. Private famedly dependencies keep working via the token; public clones (incl. all SPM packages) stay untouched. As a side effect the token is no longer attached to every GitHub clone.
