### PR TITLE
fix: authenticate token-based dependency pulls via netrc

### DIFF
--- a/.github/actions/dart-prepare/action.yml
+++ b/.github/actions/dart-prepare/action.yml
@@ -64,4 +64,14 @@ runs:
         # Rewrite ssh-style dependency URLs to HTTPS so the netrc auth applies.
         git config --global --add url."https://github.com/famedly/".insteadOf "git@github.com:famedly/"
         git config --global --add url."https://github.com/famedly/".insteadOf "ssh://git@github.com/famedly/"
+        # On macOS, force Xcode's Swift Package Manager to resolve packages
+        # with the system git (which honors gitconfig and ~/.netrc) instead of
+        # Xcode's own SCM, which consults the keychain and hangs headless CI
+        # runners. Equivalent of `xcodebuild -scmProvider system`, needed
+        # because tools like `flutter build ipa` invoke xcodebuild internally
+        # and cannot forward the flag, see
+        # https://github.com/actions/runner-images/issues/10722
+        if [[ "$(uname)" == "Darwin" ]]; then
+          defaults write com.apple.dt.Xcode IDEPackageSupportUseBuiltinSCM -bool YES
+        fi
       shell: bash

--- a/.github/actions/dart-prepare/action.yml
+++ b/.github/actions/dart-prepare/action.yml
@@ -53,12 +53,15 @@ runs:
         chown -R $(whoami) .
         if which flutter > /dev/null; then flutter --disable-analytics; fi
         if which dart > /dev/null; then dart --disable-analytics; fi
-        # --add is required: plain `git config` overwrites the previous value
-        # for the same url base key, leaving only the last insteadOf rewrite.
-        # The rewrites are scoped to the famedly org on purpose: rewriting all
-        # of github.com injects the token into public clones too, which makes
-        # Xcode's Swift Package Manager hang during dependency resolution.
-        git config --global --add url."https://x-access-token:${{ inputs.famedly_github_token }}@github.com/famedly/".insteadOf "https://github.com/famedly/"
-        git config --global --add url."https://x-access-token:${{ inputs.famedly_github_token }}@github.com/famedly/".insteadOf "git@github.com:famedly/"
-        git config --global --add url."https://x-access-token:${{ inputs.famedly_github_token }}@github.com/famedly/".insteadOf "ssh://git@github.com/famedly/"
+        # Authenticate via ~/.netrc instead of embedding the token in git URLs:
+        # git picks it up for HTTPS clones, and Xcode's Swift Package Manager
+        # uses it instead of the macOS keychain. The keychain has no UI on CI
+        # runners, which makes SPM dependency resolution hang forever, see
+        # https://github.com/actions/runner-images/issues/6233
+        printf 'machine github.com\nlogin x-access-token\npassword %s\n\nmachine api.github.com\nlogin x-access-token\npassword %s\n' \
+          "${{ inputs.famedly_github_token }}" "${{ inputs.famedly_github_token }}" > ~/.netrc
+        chmod 600 ~/.netrc
+        # Rewrite ssh-style dependency URLs to HTTPS so the netrc auth applies.
+        git config --global --add url."https://github.com/famedly/".insteadOf "git@github.com:famedly/"
+        git config --global --add url."https://github.com/famedly/".insteadOf "ssh://git@github.com/famedly/"
       shell: bash


### PR DESCRIPTION
## Summary

- `build_ios` on famedly/app#7173 hangs forever during Xcode SPM dependency resolution whenever the token-based auth path is active — regardless of whether the `insteadOf` rewrites are global (#76) or scoped to the famedly org (#77).
- Root cause is a well-known Xcode/SPM behavior: since Xcode 13.3, SPM asks the **macOS keychain** for HTTPS credentials — *even for public packages* and on changing packages each run. On a headless CI runner the keychain prompt can never be answered → infinite hang (actions/runner-images#6233, #13175). The SSH path never hit this because all fetches were rewritten to SSH.
- Documented fix from the Swift forums / runner-images issues: provide the credentials via **`~/.netrc`**. Both git (HTTPS clones for `pub get`) and xcodebuild/SPM read it, and no keychain records are created.
- The remaining `insteadOf` rewrites only map ssh-style URLs to HTTPS and contain **no credentials** — the same class of rewrite the proven SSH path uses.

## Verification

Verified locally with an isolated `$HOME` (own `.netrc`, own gitconfig, no credential helper, SSH disabled):

- `https://github.com/famedly/famedly-design.git` resolves via netrc, without any token in git URLs ✓
- `git@github.com:famedly/famedly-design.git` is rewritten to HTTPS and resolves via netrc ✓
- Public repos clone anonymously, untouched ✓
- The resulting `~/.gitconfig` contains no credentials ✓

Made with [Cursor](https://cursor.com)